### PR TITLE
fix: CommitText not returning error

### DIFF
--- a/internal/git/commit_text.go
+++ b/internal/git/commit_text.go
@@ -6,8 +6,12 @@ import (
 )
 
 // CommitMessage returns message of given commit
-func CommitMessage(repo *git.Repository, commit plumbing.Hash) string {
-	commitObject, _ := repo.CommitObject(commit)
+func CommitMessage(repo *git.Repository, commit plumbing.Hash) (string, error) {
+	commitObject, err := repo.CommitObject(commit)
 
-	return commitObject.Message
+	if err != nil {
+		return "", err
+	}
+
+	return commitObject.Message, nil
 }

--- a/internal/git/commit_text_test.go
+++ b/internal/git/commit_text_test.go
@@ -34,11 +34,12 @@ func createCommit(repo *git.Repository, message string) *object.Commit {
 	return obj
 }
 
-func TestCommitDate(t *testing.T) {
+func TestCommitMessage(t *testing.T) {
 	repo := setupRepo()
 	commit := createCommit(repo, "example commit")
 
-	message := CommitMessage(repo, commit.Hash)
+	message, err := CommitMessage(repo, commit.Hash)
 
 	assert.Equal(t, message, "example commit")
+	assert.Equal(t, err, nil)
 }


### PR DESCRIPTION
- CommitText would not propagate error higher
- fixes misleading test name