### PR TITLE
fix(CheckMessage): fix edge cases in regex

### DIFF
--- a/internal/text/check_message_title.go
+++ b/internal/text/check_message_title.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	titleRegex         = regexp.MustCompile(`^(?P<type>\w+?)(?P<scope>\(\w+\)?)*!*:\s(?P<message>.+)$`)
+	titleRegex         = regexp.MustCompile(`^(?P<type>\w+?)(?P<scope>\(\w+\)?)?!?:\s(?P<message>.+)$`)
 	errTitleNonConform = errors.New("message title does not conform to conventional commits")
 )
 

--- a/internal/text/check_message_title_test.go
+++ b/internal/text/check_message_title_test.go
@@ -8,16 +8,18 @@ import (
 
 func TestCheckMessageTitle(t *testing.T) {
 	tests := map[string]error{
-		"chore: add something":          nil,
-		"chore(ci): added new CI stuff": nil,
-		"feat: added a new feature":     nil,
-		"fix!: breaking change":         nil,
-		"fix(security)!: breaking":      nil,
-		"chore:really close":            errTitleNonConform,
-		"perf(): nope":                  errTitleNonConform,
-		"chore(: bad":                   errTitleNonConform,
-		": nope":                        errTitleNonConform,
-		"fix tests":                     errTitleNonConform,
+		"chore: add something":               nil,
+		"chore(ci): added new CI stuff":      nil,
+		"feat: added a new feature":          nil,
+		"fix!: breaking change":              nil,
+		"fix(security)!: breaking":           nil,
+		"fix!!: breaking":                    errTitleNonConform,
+		"fix(security)(stuff): should break": errTitleNonConform,
+		"chore:really close":                 errTitleNonConform,
+		"perf(): nope":                       errTitleNonConform,
+		"chore(: bad":                        errTitleNonConform,
+		": nope":                             errTitleNonConform,
+		"fix tests":                          errTitleNonConform,
 	}
 
 	for test, expected := range tests {


### PR DESCRIPTION
- fixes cases where `fix(stuff)(stuff): message` were possible
- fixes cases where double `!` was possible