### PR TITLE
fix(CommitsOnBranch): fixed CommitsOnBranch returning only 1 commit

### DIFF
--- a/internal/history/commits_on_branch.go
+++ b/internal/history/commits_on_branch.go
@@ -1,15 +1,30 @@
 package history
 
 import (
+	"errors"
+	"log"
+
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/object"
 )
 
+// ErrCommonCommitFound is used for identifying when the iterator has reached the common commit
+var ErrCommonCommitFound = errors.New("common commit found")
+
 // CommitsOnBranch iterates through all references and returns commit hashes on given branch
-func CommitsOnBranch(repo *git.Repository, branchName string) ([]plumbing.Hash, error) {
-	branchRef := plumbing.NewBranchReferenceName(branchName)
+func CommitsOnBranch(
+	repo *git.Repository,
+	branchRef plumbing.ReferenceName,
+	compareRef plumbing.ReferenceName,
+) ([]plumbing.Hash, error) {
 
 	var commits []plumbing.Hash
+	var branchHash plumbing.Hash
+	var compareHash plumbing.Hash
+
+	// common ancestor between two branches based on MergeBase
+	var commonHash plumbing.Hash
 
 	allRefs, refErr := repo.References()
 
@@ -20,8 +35,13 @@ func CommitsOnBranch(repo *git.Repository, branchName string) ([]plumbing.Hash, 
 	defer allRefs.Close()
 
 	refIterErr := allRefs.ForEach(func(ref *plumbing.Reference) error {
+		log.Println(branchRef, ref.Name().String())
 		if ref.Name() == branchRef {
-			commits = append(commits, ref.Hash())
+			branchHash = ref.Hash()
+		}
+
+		if ref.Name() == compareRef {
+			compareHash = ref.Hash()
 		}
 
 		return nil
@@ -29,6 +49,37 @@ func CommitsOnBranch(repo *git.Repository, branchName string) ([]plumbing.Hash, 
 
 	if refIterErr != nil {
 		return nil, refIterErr
+	}
+
+	branchCommit, _ := repo.CommitObject(branchHash)
+
+	compareCommit, _ := repo.CommitObject(compareHash)
+
+	diffCommits, _ := branchCommit.MergeBase(compareCommit)
+
+	commonHash = diffCommits[len(diffCommits)-1].Hash
+
+	commitIter, logErr := repo.Log(&git.LogOptions{
+		From: branchCommit.Hash,
+	})
+
+	if logErr != nil {
+		return nil, logErr
+	}
+
+	iterErr := commitIter.ForEach(func(commit *object.Commit) error {
+		if commit.Hash == commonHash {
+			return ErrCommonCommitFound
+		}
+		commits = append(commits, commit.Hash)
+		return nil
+	})
+
+	if iterErr != nil {
+		if iterErr == ErrCommonCommitFound {
+			return commits, nil
+		}
+		return nil, iterErr
 	}
 
 	return commits, nil

--- a/internal/history/commits_on_branch_test.go
+++ b/internal/history/commits_on_branch_test.go
@@ -37,15 +37,21 @@ func TestCommitsOnBranch(t *testing.T) {
 	createCommit(repo, "test commit on master")
 	createBranch(repo)
 	createCommit(repo, "commit on new branch")
+	createCommit(repo, "second commit on new branch")
+	createCommit(repo, "third commit on new branch")
 
-	commits, err := CommitsOnBranch(repo, "my-branch")
+	headRef, _ := repo.Head()
 
-	assert.Equal(t, len(commits), 1)
+	masterRef := plumbing.NewBranchReferenceName("master")
+
+	commits, err := CommitsOnBranch(repo, headRef.Name(), masterRef)
+
+	assert.Equal(t, 3, len(commits))
 
 	commit, commitErr := repo.CommitObject(commits[0])
 
 	assert.NoError(t, commitErr)
-	assert.Equal(t, commit.Message, "commit on new branch")
+	assert.Equal(t, "third commit on new branch", commit.Message)
 	assert.Equal(t, err, nil)
 
 }


### PR DESCRIPTION
- References will only list out branches etc., but not actual commits
- function has been expanded to use MergeBase
- after getting common ancestor it uses Log to iterate through commits between the head and common ancestor
- improved tests to reflect more commits on branch