### PR TITLE
fix: missing commits and passing pipeline on 0 commits

### DIFF
--- a/cmd/root_runner.go
+++ b/cmd/root_runner.go
@@ -44,9 +44,7 @@ func runRoot(cmd *cobra.Command, args []string) error {
 		return currentBranchErr
 	}
 
-	masterRef := plumbing.ReferenceName("master")
-
-	commits, commitsErr := history.CommitsOnBranch(repo, currentBranch.Name(), masterRef)
+	commits, commitsErr := history.CommitsOnBranch(repo, currentBranch.Hash(), "origin/master")
 
 	if len(commits) == 0 {
 		return errors.New("No commits found, please check you are on a branch outside of main")

--- a/cmd/root_runner.go
+++ b/cmd/root_runner.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"log"
 
 	"github.com/fallion/commitsar/internal/history"
@@ -46,6 +47,10 @@ func runRoot(cmd *cobra.Command, args []string) error {
 	masterRef := plumbing.ReferenceName("master")
 
 	commits, commitsErr := history.CommitsOnBranch(repo, currentBranch.Name(), masterRef)
+
+	if len(commits) == 0 {
+		return errors.New("No commits found, please check you are on a branch outside of main")
+	}
 
 	if commitsErr != nil {
 		return commitsErr

--- a/internal/history/commits_on_branch.go
+++ b/internal/history/commits_on_branch.go
@@ -26,11 +26,15 @@ func CommitsOnBranch(
 
 	branchCommit, err := commitFromRepo(repo, branchRef.String())
 
+	log.Println("branchCommit ", branchCommit)
+
 	if err != nil {
 		return nil, err
 	}
 
 	compareCommit, err := commitFromRepo(repo, compareRef.String())
+
+	log.Println("compareCommit ", compareCommit)
 
 	if err != nil {
 		return nil, err

--- a/internal/history/commits_on_branch.go
+++ b/internal/history/commits_on_branch.go
@@ -2,7 +2,6 @@ package history
 
 import (
 	"errors"
-	"log"
 
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -15,8 +14,8 @@ var ErrCommonCommitFound = errors.New("common commit found")
 // CommitsOnBranch iterates through all references and returns commit hashes on given branch
 func CommitsOnBranch(
 	repo *git.Repository,
-	branchRef plumbing.ReferenceName,
-	compareRef plumbing.ReferenceName,
+	branchHash plumbing.Hash,
+	compareBranch string,
 ) ([]plumbing.Hash, error) {
 
 	var commits []plumbing.Hash
@@ -24,17 +23,13 @@ func CommitsOnBranch(
 	// common ancestor between two branches based on MergeBase
 	var commonHash plumbing.Hash
 
-	branchCommit, err := commitFromRepo(repo, branchRef.String())
-
-	log.Println("branchCommit ", branchCommit)
+	branchCommit, err := repo.CommitObject(branchHash)
 
 	if err != nil {
 		return nil, err
 	}
 
-	compareCommit, err := commitFromRepo(repo, compareRef.String())
-
-	log.Println("compareCommit ", compareCommit)
+	compareCommit, err := commitFromRepo(repo, compareBranch)
 
 	if err != nil {
 		return nil, err
@@ -43,7 +38,6 @@ func CommitsOnBranch(
 	diffCommits, mergeBaseErr := branchCommit.MergeBase(compareCommit)
 
 	if mergeBaseErr != nil {
-		log.Print(mergeBaseErr)
 		return nil, mergeBaseErr
 	}
 

--- a/internal/history/commits_on_branch_test.go
+++ b/internal/history/commits_on_branch_test.go
@@ -42,9 +42,7 @@ func TestCommitsOnBranch(t *testing.T) {
 
 	headRef, _ := repo.Head()
 
-	masterRef := plumbing.NewBranchReferenceName("master")
-
-	commits, err := CommitsOnBranch(repo, headRef.Name(), masterRef)
+	commits, err := CommitsOnBranch(repo, headRef.Hash(), "master")
 
 	assert.Equal(t, 3, len(commits))
 


### PR DESCRIPTION
- fix: error on no commits found
- fix: pass head hash down instead of rebuilding from refrences
  - ResolveRevision could not find reference built of branch name, however this is not required as we already have the hash of head